### PR TITLE
Add support for replit

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,3 @@
+language = "bash"
+run = "node Kahoot-Bot-Spam-main/bot.js"
+onboot = "cd Kahoot-Bot-Spam-main && npm install"

--- a/Kahoot-Bot-Spam-main/README.md
+++ b/Kahoot-Bot-Spam-main/README.md
@@ -3,4 +3,5 @@
 
 Node.js : https://nodejs.org/en/
 
+To run this online, just [click here](https://replit.com/@luke2m/kahoot-spammer), press play, and follow the prompts.
 


### PR DESCRIPTION
This PR adds support for replit.com, a way to run the bot online with one click. It also adds a link  from the README.